### PR TITLE
Deduplicate nearly identical code between Contoller and cron hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
+# SimpleSAMLphp Module Metarefresh
+
 ![Build Status](https://github.com/simplesamlphp/simplesamlphp-module-metarefresh/workflows/CI/badge.svg?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/simplesamlphp/simplesamlphp-module-metarefresh/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/simplesamlphp/simplesamlphp-module-metarefresh/?branch=master)
 [![Coverage Status](https://codecov.io/gh/simplesamlphp/simplesamlphp-module-metarefresh/branch/master/graph/badge.svg)](https://codecov.io/gh/simplesamlphp/simplesamlphp-module-metarefresh)
 [![Type Coverage](https://shepherd.dev/github/simplesamlphp/simplesamlphp-module-metarefresh/coverage.svg)](https://shepherd.dev/github/simplesamlphp/simplesamlphp-module-metarefresh)
 [![Psalm Level](https://shepherd.dev/github/simplesamlphp/simplesamlphp-module-metarefresh/level.svg)](https://shepherd.dev/github/simplesamlphp/simplesamlphp-module-metarefresh)
+
+The metarefresh module provides periodic downloading of remote metadata files and
+updating SimpleSAMLphp's list of known entities with it. For more information,
+see [the included documentation](docs/simplesamlphp-automated_metadata.md).

--- a/docs/simplesamlphp-automated_metadata.md
+++ b/docs/simplesamlphp-automated_metadata.md
@@ -165,11 +165,7 @@ The metarefresh module supports the following configuration options:
 
 `types`
 :   The sets of entities to load. An array containing strings identifying the different types of entities that will be
-    loaded. Valid types are:
-    * saml20-idp-remote
-    * saml20-sp-remote
-    * attributeauthority-remote
-
+    loaded. Valid types are: `saml20-idp-remote`, `saml20-sp-remote`, `attributeauthority-remote`.
     All entity types will be loaded by default.
 
 Each metadata source has the following options:
@@ -210,7 +206,7 @@ Each metadata source has the following options:
 `attributewhitelist`
 :   This is a multilevel array for selectively refreshing a list of identity providers based on specific attributes
     patterns in their metadata. Only data from identity providers that match at least one element of the top-level array
-    will be processed and written to disk.   
+    will be processed and written to disk.
     Matching of such a top-level element, itself being a (multi-level) array, means that at each level (recursively) the
     key and value match with the identity provider's metadata. Scalar keys and values are matched using PCRE.
     A typical use-case is to accept only identity providers from eduGAIN that match a combination of specific

--- a/docs/simplesamlphp-automated_metadata.md
+++ b/docs/simplesamlphp-automated_metadata.md
@@ -166,7 +166,6 @@ The metarefresh module supports the following configuration options:
 `types`
 :   The sets of entities to load. An array containing strings identifying the different types of entities that will be
     loaded. Valid types are:
-
     * saml20-idp-remote
     * saml20-sp-remote
     * attributeauthority-remote
@@ -213,10 +212,10 @@ Each metadata source has the following options:
     patterns in their metadata. Only data from identity providers that match at least one element of the top-level array
     will be processed and written to disk.   
     Matching of such a top-level element, itself being a (multi-level) array, means that at each level (recursively) the
-    key and value match with the identity provider's metadata. Scalar keys and values are matched using PCRE.   
+    key and value match with the identity provider's metadata. Scalar keys and values are matched using PCRE.
     A typical use-case is to accept only identity providers from eduGAIN that match a combination of specific
-    EntityAttributes, such as the https://refeds.org/sirtfi assurance-certification *and*
-    http://refeds.org/category/research-and-scholarship entity-category.   
+    EntityAttributes, such as the `https://refeds.org/sirtfi` assurance-certification *and*
+    `http://refeds.org/category/research-and-scholarship` entity-category.
     Another example is filtering identity providers from a specific federation, by filtering on specific values of the
     registrationAuthority inside the RegistrationInfo.
 
@@ -229,7 +228,7 @@ chown www-data /var/simplesamlphp/metadata/metarefresh-ukaccess/
 ```
 
 Now you can configure SimpleSAMLphp to use the metadata fetched by metarefresh. Edit the main
-config.php file, and modify the `metadata.sources` directive accordingly: 
+config.php file, and modify the `metadata.sources` directive accordingly:
 
 ```php
 'metadata.sources' => [

--- a/hooks/hook_cron.php
+++ b/hooks/hook_cron.php
@@ -16,117 +16,13 @@ function metarefresh_hook_cron(array &$croninfo): void
 
     Logger::info('cron [metarefresh]: Running cron in cron tag [' . $croninfo['tag'] . '] ');
 
+    $config = Configuration::getInstance();
+    $mconfig = Configuration::getOptionalConfig('module_metarefresh.php');
+
+    $mf = new \SimpleSAML\Module\metarefresh\MetaRefresh($config, $mconfig);
+
     try {
-        $config = Configuration::getInstance();
-        $mconfig = Configuration::getOptionalConfig('module_metarefresh.php');
-
-        $sets = $mconfig->getArray('sets');
-        /** @var string $datadir */
-        $datadir = $config->getPathValue('datadir', 'data/');
-        $stateFile = $datadir . 'metarefresh-state.php';
-
-        foreach ($sets as $setkey => $set) {
-            $set = Configuration::loadFromArray($set);
-
-            // Only process sets where cron matches the current cron tag
-            $cronTags = $set->getArray('cron');
-            if (!in_array($croninfo['tag'], $cronTags, true)) {
-                continue;
-            }
-
-            Logger::info('cron [metarefresh]: Executing set [' . $setkey . ']');
-
-            $expireAfter = $set->getInteger('expireAfter', null);
-            if ($expireAfter !== null) {
-                $expire = time() + $expireAfter;
-            } else {
-                $expire = null;
-            }
-
-            $outputDir = $set->getString('outputDir');
-            $outputDir = $config->resolvePath($outputDir);
-            if ($outputDir === null) {
-                throw new \Exception("Invalid outputDir specified.");
-            }
-
-            $outputFormat = $set->getValueValidate('outputFormat', ['flatfile', 'serialize'], 'flatfile');
-
-            $oldMetadataSrc = \SimpleSAML\Metadata\MetaDataStorageSource::getSource([
-                'type' => $outputFormat,
-                'directory' => $outputDir,
-            ]);
-
-            $metaloader = new \SimpleSAML\Module\metarefresh\MetaLoader($expire, $stateFile, $oldMetadataSrc);
-
-            // Get global blacklist, whitelist, attributewhitelist and caching info
-            $blacklist = $mconfig->getOptionalArray('blacklist', []);
-            $whitelist = $mconfig->getOptionalArray('whitelist', []);
-            $attributewhitelist = $mconfig->getOptionalArray('attributewhitelist', []);
-            $conditionalGET = $mconfig->getOptionalBoolean('conditionalGET', false);
-
-            // get global type filters
-            $available_types = [
-                'saml20-idp-remote',
-                'saml20-sp-remote',
-                'attributeauthority-remote'
-            ];
-            $set_types = $set->getArrayize('types', $available_types);
-
-            foreach ($set->getArray('sources') as $source) {
-                // filter metadata by type of entity
-                if (isset($source['types'])) {
-                    $metaloader->setTypes($source['types']);
-                } else {
-                    $metaloader->setTypes($set_types);
-                }
-
-                // Merge global and src specific blacklists
-                if (isset($source['blacklist'])) {
-                    $source['blacklist'] = array_unique(array_merge($source['blacklist'], $blacklist));
-                } else {
-                    $source['blacklist'] = $blacklist;
-                }
-
-                // Merge global and src specific whitelists
-                if (isset($source['whitelist'])) {
-                    $source['whitelist'] = array_unique(array_merge($source['whitelist'], $whitelist));
-                } else {
-                    $source['whitelist'] = $whitelist;
-                }
-
-                # Merge global and src specific attributewhitelists: cannot use array_unique for multi-dim.
-                if (isset($source['attributewhitelist'])) {
-                    $source['attributewhitelist'] = array_merge($source['attributewhitelist'], $attributewhitelist);
-                } else {
-                    $source['attributewhitelist'] = $attributewhitelist;
-                }
-
-                // Let src specific conditionalGET override global one
-                if (!isset($source['conditionalGET'])) {
-                    $source['conditionalGET'] = $conditionalGET;
-                }
-
-                Logger::debug('cron [metarefresh]: In set [' . $setkey . '] loading source [' . $source['src'] . ']');
-                $metaloader->loadSource($source);
-            }
-
-            // Write state information back to disk
-            $metaloader->writeState();
-
-            switch ($outputFormat) {
-                case 'flatfile':
-                    $metaloader->writeMetadataFiles($outputDir);
-                    break;
-                case 'serialize':
-                    $metaloader->writeMetadataSerialize($outputDir);
-                    break;
-            }
-
-            if ($set->hasValue('arp')) {
-                $arpconfig = Configuration::loadFromArray($set->getValue('arp'));
-                $metaloader->writeARPfile($arpconfig);
-            }
-        }
+        $mf->runRefresh($croninfo['tag']);
     } catch (\Exception $e) {
         $croninfo['summary'][] = 'Error during metarefresh: ' . $e->getMessage();
     }

--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -410,7 +410,8 @@ class MetaLoader
             foreach ($this->oldMetadataSrc->getMetadataSet($type) as $entity) {
                 if (array_key_exists('metarefresh:src', $entity)) {
                     if ($entity['metarefresh:src'] == $source['src']) {
-                        Logger::debug(sprintf('Adding cached meatadata for %s, %s',
+                        Logger::debug(sprintf(
+                            'Adding cached meatadata for %s, %s',
                             $source['src'],
                             $type
                         ));

--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -205,6 +205,7 @@ class MetaLoader
             }
         }
 
+        Logger::debug(sprintf('Found %d entities', count($entities)));
         $this->saveState($source, $responseHeaders);
     }
 
@@ -398,19 +399,22 @@ class MetaLoader
         return ['http' => ['header' => $rawheader]];
     }
 
-
-    /**
-     * @param array $source
-     */
     private function addCachedMetadata(array $source): void
     {
-        if (isset($this->oldMetadataSrc)) {
-            foreach ($this->types as $type) {
-                foreach ($this->oldMetadataSrc->getMetadataSet($type) as $entity) {
-                    if (array_key_exists('metarefresh:src', $entity)) {
-                        if ($entity['metarefresh:src'] == $source['src']) {
-                            $this->addMetadata($source['src'], $entity, $type);
-                        }
+        if (!isset($this->oldMetadataSrc)) {
+            Logger::info('No oldMetadataSrc, cannot re-use cached metadata');
+            return;
+        }
+
+        foreach ($this->types as $type) {
+            foreach ($this->oldMetadataSrc->getMetadataSet($type) as $entity) {
+                if (array_key_exists('metarefresh:src', $entity)) {
+                    if ($entity['metarefresh:src'] == $source['src']) {
+                        Logger::debug(sprintf('Adding cached meatadata for %s, %s',
+                            $source['src'],
+                            $type
+                        ));
+                        $this->addMetadata($source['src'], $entity, $type);
                     }
                 }
             }

--- a/src/MetaRefresh.php
+++ b/src/MetaRefresh.php
@@ -55,7 +55,7 @@ class MetaRefresh
 
             Logger::info('[metarefresh]: Executing set [' . $setkey . ']');
 
-            $expireAfter = $set->getInteger('expireAfter', null);
+            $expireAfter = $set->getOptionalInteger('expireAfter', null);
             if ($expireAfter !== null) {
                 $expire = time() + $expireAfter;
             } else {

--- a/src/MetaRefresh.php
+++ b/src/MetaRefresh.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimpleSAML\Module\metarefresh;
+
+use Exception;
+use SimpleSAML\Assert\Assert;
+use SimpleSAML\Configuration;
+use SimpleSAML\Logger;
+use SimpleSAML\Metadata\MetaDataStorageSource;
+use SimpleSAML\Module;
+
+class MetaRefresh
+{
+    /**
+     * @var \SimpleSAML\Configuration
+     */
+    private Configuration $config;
+
+    /**
+     * @var \SimpleSAML\Configuration
+     */
+    private Configuration $modconfig;
+
+    /**
+     * @param \SimpleSAML\Configuration              $config The configuration to use by the module.
+     * @param \SimpleSAML\Configuration              $modconfig The module-specific configuration to use by the module.
+     */
+    public function __construct(Configuration $config, Configuration $modconfig)
+    {
+        $this->config = $config;
+        $this->modconfig = $modconfig;
+    }
+
+    /**
+     * @param string $crontag Only refresh sets which allow this crontag
+     */
+    public function runRefresh(string $crontag = null): void
+    {
+        $sets = $this->modconfig->getArray('sets');
+        /** @var string $datadir */
+        $datadir = $this->config->getPathValue('datadir', 'data/');
+        $stateFile = $datadir . 'metarefresh-state.php';
+
+        foreach ($sets as $setkey => $set) {
+            $set = Configuration::loadFromArray($set);
+
+            // Only process sets where cron matches the current cron tag
+            $cronTags = $set->getArray('cron');
+            if ($crontag !== null && !in_array($crontag, $cronTags, true)) {
+                Logger::debug('[metarefresh]: Skipping set [' . $setkey . '], not allowed for cron tag ' . $tag);
+                continue;
+            }
+
+            Logger::info('[metarefresh]: Executing set [' . $setkey . ']');
+
+            $expireAfter = $set->getInteger('expireAfter', null);
+            if ($expireAfter !== null) {
+                $expire = time() + $expireAfter;
+            } else {
+                $expire = null;
+            }
+
+            $outputDir = $set->getString('outputDir');
+            $outputDir = $this->config->resolvePath($outputDir);
+            if ($outputDir === null) {
+                throw new Exception("Invalid outputDir specified.");
+            }
+
+            $outputFormat = $set->getValueValidate('outputFormat', ['flatfile', 'serialize'], 'flatfile');
+
+            $oldMetadataSrc = MetaDataStorageSource::getSource([
+                'type' => $outputFormat,
+                'directory' => $outputDir,
+            ]);
+
+            $metaloader = new MetaLoader($expire, $stateFile, $oldMetadataSrc);
+
+            // Get global blacklist, whitelist, attributewhitelist and caching info
+            $blacklist = $this->modconfig->getOptionalArray('blacklist', []);
+            $whitelist = $this->modconfig->getOptionalArray('whitelist', []);
+            $attributewhitelist = $this->modconfig->getOptionalArray('attributewhitelist', []);
+            $conditionalGET = $this->modconfig->getOptionalBoolean('conditionalGET', false);
+
+            // get global type filters
+            $available_types = [
+                'saml20-idp-remote',
+                'saml20-sp-remote',
+                'attributeauthority-remote'
+            ];
+            $set_types = $set->getOptionalArray('types', $available_types);
+
+            foreach ($set->getArray('sources') as $source) {
+                // filter metadata by type of entity
+                if (isset($source['types'])) {
+                    $metaloader->setTypes($source['types']);
+                } else {
+                    $metaloader->setTypes($set_types);
+                }
+
+                // Merge global and src specific blacklists
+                if (isset($source['blacklist'])) {
+                    $source['blacklist'] = array_unique(array_merge($source['blacklist'], $blacklist));
+                } else {
+                    $source['blacklist'] = $blacklist;
+                }
+
+                // Merge global and src specific whitelists
+                if (isset($source['whitelist'])) {
+                    $source['whitelist'] = array_unique(array_merge($source['whitelist'], $whitelist));
+                } else {
+                    $source['whitelist'] = $whitelist;
+                }
+
+                # Merge global and src specific attributewhitelists: cannot use array_unique for multi-dim.
+                if (isset($source['attributewhitelist'])) {
+                    $source['attributewhitelist'] = array_merge($source['attributewhitelist'], $attributewhitelist);
+                } else {
+                    $source['attributewhitelist'] = $attributewhitelist;
+                }
+
+                // Let src specific conditionalGET override global one
+                if (!isset($source['conditionalGET'])) {
+                    $source['conditionalGET'] = $conditionalGET;
+                }
+
+                Logger::debug('[metarefresh]: In set [' . $setkey . '] loading source [' . $source['src'] . ']');
+                $metaloader->loadSource($source);
+            }
+
+            // Write state information back to disk
+            $metaloader->writeState();
+
+            switch ($outputFormat) {
+                case 'flatfile':
+                    $metaloader->writeMetadataFiles($outputDir);
+                    break;
+                case 'serialize':
+                    $metaloader->writeMetadataSerialize($outputDir);
+                    break;
+            }
+
+            if ($set->hasValue('arp')) {
+                $arpconfig = Configuration::loadFromArray($set->getValue('arp'));
+                $metaloader->writeARPfile($arpconfig);
+            }
+        }
+    }
+}

--- a/tests/src/ARPTest.php
+++ b/tests/src/ARPTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SimpleSAML\Test\Module\metarefresh;
+
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\metarefresh\ARP;
+
+class ARPTest extends TestCase
+{
+    function testARP()
+    {
+        $config = Configuration::loadFromArray(
+            ['module.enable' => ['metarefresh' => true]],
+            '[ARRAY]',
+            'simplesaml'
+        );
+        Configuration::setPreLoadedConfig($config, 'config.php');
+
+        $metadata = [1=>['metadata'=>['entityid'=>'urn:test:loeki.tv', 'attributes' => ['aap','noot','mobile']]]];
+        $attributemap = 'test';
+        $prefix = 'beforeit';
+        $suffix = 'thereafter';
+
+        $arp = new ARP($metadata, $attributemap, $prefix, $suffix);
+
+        $xml = $arp->getXML();
+        $expectentity = 'AttributeFilterPolicy id="urn:test:loeki.tv"><PolicyRequirementRule xsi:type="basic:AttributeRequesterString" value="urn:test:loeki.tv';
+        $expectattributeunmapped = '<AttributeRule attributeID="beforeitnootthereafter"><PermitValueRule xsi:type="basic:ANY" /></AttributeRule>';
+        $expectattributemapped = '<AttributeRule attributeID="beforeiturn:mace:dir:attribute-def:mobilethereafter">';
+
+        $this->assertStringContainsString($expectentity, $xml);
+        $this->assertStringContainsString($expectattributeunmapped, $xml);
+        $this->assertStringContainsString($expectattributemapped, $xml);
+        
+    }
+}

--- a/tests/src/Controller/MetaRefreshTest.php
+++ b/tests/src/Controller/MetaRefreshTest.php
@@ -103,9 +103,8 @@ class MetaRefreshTest extends TestCase
             '/',
             'GET'
         );
-        $session = Session::getSessionFromRequest();
 
-        $c = new Controller\MetaRefresh($this->config, $session);
+        $c = new Controller\MetaRefresh($this->config);
         $c->setAuthUtils($this->authUtils);
         $c->setModuleConfig($this->module_config);
 

--- a/tests/src/Controller/MetaRefreshTest.php
+++ b/tests/src/Controller/MetaRefreshTest.php
@@ -112,5 +112,10 @@ class MetaRefreshTest extends TestCase
         $response = $c->main($request);
 
         $this->assertTrue($response->isSuccessful());
+
+        $contents = $response->getContents();
+        $this->assertStringContainsString('[metarefresh]: Executing set [example]', $contents);
+        $this->assertStringContainsString('In set [example] loading source', $contents);
+        $this->assertStringContainsString('attempting to re-use cached metadata', $contents);
     }
 }


### PR DESCRIPTION
Introduces a new class MetaRefresh that can hold the code that is invoked via the cron hook and via the admin interface controller.

This not only saves duplicate code but also resolves a number of unneeded behavioral differences between the two invocations.