### PR TITLE
Stop cleaning up expired enties at the end of the run.

### DIFF
--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -656,35 +656,6 @@ class MetaLoader
                 $metaHandler->saveMetadata($entityId, $set, $m['metadata']);
             }
         }
-
-        // Then we delete old entries which should no longer exist
-        $ct = time();
-        foreach ($metaHandler->getMetadataSets() as $set) {
-            foreach ($metaHandler->getMetadataSet($set) as $entityId => $metadata) {
-                if (!array_key_exists('expire', $metadata) || !is_int($metadata['expire'])) {
-                    Logger::warning(
-                        'metarefresh: Metadata entry without valid expire timestamp: ' . var_export($entityId, true) .
-                        ' in set ' . var_export($set, true) . '.'
-                    );
-                    continue;
-                }
-
-                $expire = $metadata['expire'];
-                if ($expire > $ct) {
-                    continue;
-                }
-
-                /** @var int $stamp */
-                $stamp = date('l jS \of F Y h:i:s A', $expire);
-                Logger::debug('metarefresh: ' . $entityId . ' expired ' . $stamp);
-                Logger::debug(
-                    'metarefresh: Delete expired metadata entry ' .
-                    var_export($entityId, true) . ' in set ' . var_export($set, true) .
-                    '. (' . ($ct - $expire) . ' sec)'
-                );
-                $metaHandler->deleteMetadata($entityId, $set);
-            }
-        }
     }
 
 

--- a/tests/src/MetaLoaderTest.php
+++ b/tests/src/MetaLoaderTest.php
@@ -140,6 +140,28 @@ class MetaLoaderTest extends TestCase
         );
     }
 
+    /**
+     * Tests that setting an explicit expiry time will be added to the resulting
+     * metadata when the original metadata lacks one.
+     */
+    public function testMetaLoaderSetExpiryWhenNotPresent(): void
+    {
+        $metaloader = new \SimpleSAML\Module\metarefresh\MetaLoader(1000);
+
+        $metaloader->loadSource($this->source);
+        $metaloader->dumpMetadataStdOut();
+
+        $output = $this->getActualOutput();
+        try {
+            eval($output);
+        } catch (\Exception $e) {
+            $this->fail('Metarefresh does not produce syntactially valid code');
+        }
+        $this->assertArrayHasKey('https://idp.example.com/idp/shibboleth', $metadata);
+        $this->assertArrayHasKey('expire', $metadata['https://idp.example.com/idp/shibboleth']);
+        $this->assertEquals(1000, $metadata['https://idp.example.com/idp/shibboleth']['expire']);
+    }
+
     /*
      * Test two matching EntityAttributes (R&S + Sirtfi)
      */


### PR DESCRIPTION
Expired entries will have an 'expire' field in the generated metadata.
SimpleSAMLphp knows how to deal with this and will enforce the expiry.
By not cleaning them up we can:
- Make it explicit in the admin UI that the entry has expired instead of
  it just becoming invisible;
- Give explicit error messages about expiry instead of 'unknown entity'
  when people are trying to authenticate to this entity;
- Have less code overall.

Also add a unit test to test the expiry config part.