### PR TITLE
Force refetching source if our cached copy will expire

### DIFF
--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\metarefresh;
 
+use DateTimeImmutable;
 use Exception;
 use SimpleSAML\Configuration;
 use SimpleSAML\Logger;
@@ -387,6 +388,23 @@ class MetaLoader
         if (isset($source['conditionalGET']) && $source['conditionalGET']) {
             if (array_key_exists($source['src'], $this->state)) {
                 $sourceState = $this->state[$source['src']];
+
+                /*
+                 * If an expireAfter value exists, we effectively altered the metadata's validUntil ourselves
+                 * so we may need to refresh the metadata even if the source indicates it has not changed.
+                 */
+                if (isset($source['expireAfter']) && isset($sourceState['requested_at'])) {
+                    $requestedAt = (new DateTimeImmutable($sourceState['requested_at']))->getTimestamp();
+                    if ($requestedAt + $source['expireAfter'] <= time() - 3600) { // 1 hour based on default cron tags
+                        Logger::info(sprintf(
+                            'Cached metadata for %s expires soon - forcing refresh even if not changed',
+                            $source['src'],
+                        ));
+                        unset($sourceState['last-modified']);
+                        unset($sourceState['etag']);
+                        $rawheader .= 'Cache-Control: max-age=0' . "\r\n";
+                    }
+                }
 
                 if (isset($sourceState['last-modified'])) {
                     $rawheader .= 'If-Modified-Since: ' . $sourceState['last-modified'] . "\r\n";

--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimpleSAML\Module\metarefresh;
 
+use DateInterval;
 use DateTimeImmutable;
 use Exception;
 use SimpleSAML\Configuration;
@@ -394,8 +395,11 @@ class MetaLoader
                  * so we may need to refresh the metadata even if the source indicates it has not changed.
                  */
                 if (isset($source['expireAfter']) && isset($sourceState['requested_at'])) {
-                    $requestedAt = (new DateTimeImmutable($sourceState['requested_at']))->getTimestamp();
-                    if ($requestedAt + $source['expireAfter'] <= time() - 3600) { // 1 hour based on default cron tags
+                    $requestedAt = new DateTimeImmutable($sourceState['requested_at']);
+                    $expiresAt = $requestedAt->add(new DateInterval('PT' . $source['expireAfter'] . 'S'));
+                    $refreshThreshold = $expiresAt->sub(new DateInterval('PT1H')); // 1 hour based on default cron tags
+                    $now = new DateTimeImmutable();
+                    if ($now >= $refreshThreshold) {
                         Logger::info(sprintf(
                             'Cached metadata for %s expires soon - forcing refresh even if not changed',
                             $source['src'],

--- a/src/MetaRefresh.php
+++ b/src/MetaRefresh.php
@@ -111,7 +111,7 @@ class MetaRefresh
                     $source['whitelist'] = $whitelist;
                 }
 
-                # Merge global and src specific attributewhitelists: cannot use array_unique for multi-dim.
+                // Merge global and src specific attributewhitelists: cannot use array_unique for multi-dim.
                 if (isset($source['attributewhitelist'])) {
                     $source['attributewhitelist'] = array_merge($source['attributewhitelist'], $attributewhitelist);
                 } else {
@@ -121,6 +121,11 @@ class MetaRefresh
                 // Let src specific conditionalGET override global one
                 if (!isset($source['conditionalGET'])) {
                     $source['conditionalGET'] = $conditionalGET;
+                }
+
+                // make our cache expiry available to the loader if we're conditionally GETting
+                if ($source['conditionalGET'] && isset($expireAfter)) {
+                    $source['expireAfter'] = $expireAfter;
                 }
 
                 Logger::debug('[metarefresh]: In set [' . $setkey . '] loading source [' . $source['src'] . ']');


### PR DESCRIPTION
If we set the `expiresAfter` option in metarefresh's config, we effectively alter the inbound metadata. Thus when we're conditionally GETting, we need to be aware that we've introduced a validUntil attribute that the remote server may not know about. That means we might need to force a refresh of the source even if the remote server does not think it has been modified.