### PR TITLE
Fix PHPdoc return tags and a code warning

### DIFF
--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -214,7 +214,7 @@ class MetaLoader
     /**
      * @param \SimpleSAML\Metadata\SAMLParser $entity
      * @param array $source
-     * @bool
+     * @return bool
      */
     private function processCertificates(Metadata\SAMLParser $entity, array $source): bool
     {
@@ -234,7 +234,7 @@ class MetaLoader
     /**
      * @param \SimpleSAML\Metadata\SAMLParser $entity
      * @param array $source
-     * @bool
+     * @return bool
      */
     private function processBlacklist(Metadata\SAMLParser $entity, array $source): bool
     {
@@ -251,7 +251,7 @@ class MetaLoader
     /**
      * @param \SimpleSAML\Metadata\SAMLParser $entity
      * @param array $source
-     * @bool
+     * @return bool
      */
     private function processWhitelist(Metadata\SAMLParser $entity, array $source): bool
     {
@@ -268,7 +268,7 @@ class MetaLoader
     /**
      * @param \SimpleSAML\Metadata\SAMLParser $entity
      * @param array $source
-     * @bool
+     * @return bool
      */
     private function processAttributeWhitelist(Metadata\SAMLParser $entity, array $source): bool
     {

--- a/src/MetaRefresh.php
+++ b/src/MetaRefresh.php
@@ -66,7 +66,7 @@ class MetaRefresh
                 throw new Exception("Invalid outputDir specified.");
             }
 
-            $outputFormat = $set->getValueValidate('outputFormat', ['flatfile', 'serialize', 'pdo'], 'flatfile');
+            $outputFormat = $set->getValueValidate('outputFormat', ['flatfile', 'serialize', 'pdo']);
 
             $oldMetadataSrc = MetaDataStorageSource::getSource([
                 'type' => $outputFormat,


### PR DESCRIPTION
- Added @return tags
- Removed additional parameter in function call - if it was intended to be a default, or worked as one a long time ago, it would be caught by the Assert now