### PR TITLE
This appears to be the only place that is causing the entityid issue

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         php-version: ['8.3', '8.4', '8.5']
 
-    uses: simplesamlphp/simplesamlphp-test-framework/.github/workflows/reusable_phplinter.yml@v1.11.1
+    uses: simplesamlphp/simplesamlphp-test-framework/.github/workflows/reusable_phplinter.yml@v1.11.3
     with:
       php-version: ${{ matrix.php-version }}
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    uses: simplesamlphp/simplesamlphp-test-framework/.github/workflows/reusable_linter.yml@v1.11.1
+    uses: simplesamlphp/simplesamlphp-test-framework/.github/workflows/reusable_linter.yml@v1.11.3
     with:
       enable_eslinter: false
       enable_jsonlinter: true
@@ -276,6 +276,6 @@ jobs:
       (needs.unit-tests-linux.result == 'success' && needs.coverage.result == 'skipped')
 
     steps:
-      - uses: geekyeggo/delete-artifact@v5
+      - uses: geekyeggo/delete-artifact@v6
         with:
           name: coverage-data

--- a/src/MetaLoader.php
+++ b/src/MetaLoader.php
@@ -199,7 +199,7 @@ class MetaLoader
                 if (count($attributeAuthorities) && !empty($attributeAuthorities[0])) {
                     $this->addMetadata(
                         $source['src'],
-                        $attributeAuthorities,
+                        $attributeAuthorities[0],
                         'attributeauthority-remote',
                         $template,
                     );


### PR DESCRIPTION
I am still not sure why this is happening. But it is only being made in the `attributeauthority-remote` by this one block of code for some test federation files I have.

This was mentioned here https://github.com/simplesamlphp/simplesamlphp-module-metarefresh/pull/64