### PR TITLE
Drop dev version specifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 
         "simplesamlphp/assert": "^2.0",
         "simplesamlphp/composer-module-installer": "^1.7",
-        "simplesamlphp/simplesamlphp": "~2.5@dev",
+        "simplesamlphp/simplesamlphp": "~2.5",
         "simplesamlphp/xml-common": "~2.7",
         "symfony/http-foundation": "~7.4",
         "symfony/http-client": "~7.4",


### PR DESCRIPTION
SimpleSAMLphp version 2.5.0 is available now. Specifying the dev package is no longer required.

Closes #73 